### PR TITLE
Supply absolute path of temporary exim config file

### DIFF
--- a/email/exim4/Makefile
+++ b/email/exim4/Makefile
@@ -7,7 +7,7 @@ snippets     := $(shell find $(CURDIR)/$(snippets_dir) -mindepth 1 -regextype po
 ifeq ($(program),dovecot)
 test_args = -a -c $(conf_tmp)
 else ifeq ($(program),exim4)
-test_args = -bV -C $(conf_tmp)
+test_args = -bV -C $(CURDIR)/$(conf_tmp)
 endif
 
 all: $(conf)


### PR DESCRIPTION
Without an absolute path, make gives an "only absolute names are allowed" error.
