### PR TITLE
Fix permissions and ownership issues on log files.

### DIFF
--- a/httpd-logger/symbiosis-httpd-logger.go
+++ b/httpd-logger/symbiosis-httpd-logger.go
@@ -597,9 +597,9 @@ func main() {
 			// We match the UID/GID/mode of the handle to the top-level /srv/$domain
 			// directory, which we found earlier.
 			//
-			// Remove the executable bit though.
+			// Remove the executable and non-permissions bits.
 			//
-			mode := (stat.Mode() - (stat.Mode() & 0111))
+			mode := stat.Mode() & (os.ModePerm &^ 0111)
 
 			// Ensure the UID/GID of the logfile match that on the
 			// virtual-hosts' directory

--- a/httpd-logger/symbiosis-httpd-logger.go
+++ b/httpd-logger/symbiosis-httpd-logger.go
@@ -503,6 +503,12 @@ func main() {
 		//
 		if handles[default_file] == nil {
 			handles[default_file] = safeOpen(default_file)
+			h := handles[default_file]
+
+			if h != nil {
+				h.Chown(int(*g_uid), int(*g_gid))
+				h.Chmod(0644)
+			}
 		}
 
 		//


### PR DESCRIPTION
Fixes for issues #9 and #11.

If the directory containing the log files has, for example, setgid set,
the current code will set the setgid bit on logfiles. As non-executable
regular files, this is pointless, and means that gzip, for one, won't
process the file.

So only apply permission bits from the directory mode to the log file.
The executable bits are already turned off, so in effect the log file
will now just inherit user and group permissions from the directory.
Non-permission bits such as set(u|g)id and the sticky bit will not be
applied to the log file.

Also set the ownership and permission 0644 on default log files, following example of the Ruby logger.