### PR TITLE
Remove xmpp dovecot restarts

### DIFF
--- a/xmpp/debian/changelog
+++ b/xmpp/debian/changelog
@@ -1,3 +1,10 @@
+symbiosis-xmpp (2015:1027) UNRELEASED; urgency=medium
+
+  * Do not restart dovecot on install/remove, as no extra dovecot
+    configuration snippet is used.
+
+ -- Patrick J Cherry <patrick@bytemark.co.uk>  Tue, 08 Aug 2017 15:16:02 +0100
+
 symbiosis-xmpp (2015:1026) oldstable; urgency=medium
 
   * Ensure manpages are built.

--- a/xmpp/debian/postinst
+++ b/xmpp/debian/postinst
@@ -28,18 +28,9 @@ fi
 symbiosis-xmpp-configure --verbose
 
 #
-#  Rebuild dovecot
+# Restart prosody
 #
-if [ -e /etc/dovecot/Makefile ] ; then
-    cd /etc/dovecot && make
-fi
-
-#
-#  Restart all daemons
-#
-for i in prosody dovecot; do
-  invoke-rc.d $i restart || true
-done
+invoke-rc.d prosody restart || true
 
 #DEBHELPER#
 exit 0

--- a/xmpp/debian/postrm
+++ b/xmpp/debian/postrm
@@ -11,7 +11,7 @@ for i in {client,server} ; do
 done
 
 #
-# Restart all deamons
+# Restart all daemons
 #
 invoke-rc.d $i prosody || true
 

--- a/xmpp/debian/postrm
+++ b/xmpp/debian/postrm
@@ -11,18 +11,9 @@ for i in {client,server} ; do
 done
 
 #
-#  Rebuild dovecot
+# Restart all deamons
 #
-if [ -e /etc/dovecot/Makefile ] ; then
-    cd /etc/dovecot && make
-fi
-
-#
-#  Restart all deamons
-#
-for i in prosody dovecot; do
-  invoke-rc.d $i restart || true
-done
+invoke-rc.d $i prosody || true
 
 #DEBHELPER#
 exit 0


### PR DESCRIPTION
These are no longer required, as the special dovecot auth socket config was removed ages ago!