### PR TITLE
Disable statistics by default

### DIFF
--- a/httpd/debian/symbiosis-httpd.postinst
+++ b/httpd/debian/symbiosis-httpd.postinst
@@ -67,6 +67,20 @@ if [ -e /usr/share/apache2/apache2-maintscript-helper ] ; then
   done
 fi
 
+# change "no-stats" file to "stats" file
+for domain in /srv/*; do
+  [ -h "$domain" ] && continue;
+  [ -d "$domain" ] && continue;
+
+  no_stats="$domain/config/no-stats"
+  stats="$domain/config/stats-enabled"
+  echo false > "$stats"
+
+  if [ -e "$no_stats" ]; then
+    grep false "$no_stats" >/dev/null && echo "true" > "$stats"
+  fi
+done
+
 
 #
 # Reconfigure apache.

--- a/httpd/debian/symbiosis-httpd.postinst
+++ b/httpd/debian/symbiosis-httpd.postinst
@@ -73,12 +73,15 @@ for domain in /srv/*; do
   [ -d "$domain" ] && continue;
 
   no_stats="$domain/config/no-stats"
-  stats="$domain/config/stats-enabled"
-  echo false > "$stats"
-
-  if [ -e "$no_stats" ]; then
-    grep false "$no_stats" >/dev/null && echo "true" > "$stats"
+  stats="$domain/config/stats"
+  if [ -e "$no_stats" ] && ( grep -q false "$no_stats" ) ; then
+    # Use cp to maintain permissions, and follow symlinks, removing any destination file first.
+    cp -aL --remove-destination $no_stats $stats
+    truncate -s 0 $stats
   fi
+
+  # remove the old no-stats file
+  [ -f "$no_stats" ] && rm "$no_stats"
 done
 
 

--- a/httpd/lib/symbiosis/domain/http.rb
+++ b/httpd/lib/symbiosis/domain/http.rb
@@ -8,17 +8,7 @@ module Symbiosis
     # Returns true if statistics should be generated, false if not.
     #
     def should_have_stats?
-      bool = get_param("no-stats", self.config_dir)
-
-      #
-      # We invert the flag, since it is called "no-stats".
-      #
-      return true if false == bool or bool.nil?
-
-      #
-      # Return false if the flag exists at all.
-      #
-      return false
+      get_param('stats', self.config_dir) != false
     end
 
     #
@@ -28,16 +18,7 @@ module Symbiosis
     def should_have_stats=(bool)
       return ArgumentError, "Expecting true or false" unless [TrueClass, FalseClass].include?(bool.class)
 
-      #
-      # Invert the setting, since it is called "no-stats"
-      #
-      if true == bool
-        set_param("no-stats", false, self.config_dir)
-      else 
-        set_param("no-stats", true, self.config_dir)
-      end
-
-      return bool
+      set_param("stats", bool, self.config_dir)
     end
 
     #


### PR DESCRIPTION
I've replaced the no-stats file with a 'stats' file so the default is now for statistics to be disabled.

This will need reflecting in the documentation which I can look into if you like? We should probably write a little recommendation that users ensure that statistics are only enabled when the directory has a .htaccess file with either password or IP based security, too.

Closes #51 