### PR TITLE
Add common postinst hostname check

### DIFF
--- a/common/debian/changelog
+++ b/common/debian/changelog
@@ -1,3 +1,9 @@
+symbiosis-common (2017:0901) stable; urgency=medium
+
+  * Update postinstall hostname check to ensure HOSTNAME is qualfied.
+
+ -- Patrick J Cherry <patrick@bytemark.co.uk>  Fri, 01 Sep 2017 09:28:20 +0100
+
 symbiosis-common (2017:0830) stable; urgency=medium
 
   * Add support for running hooks on SSL certificate updates.

--- a/common/debian/postinst
+++ b/common/debian/postinst
@@ -63,6 +63,13 @@ if [ -z "$HOSTNAME" ] ; then
 fi
 
 #
+# Append ".localdomain" if HOSTNAME has no dots.
+#
+if ! [[ "$HOSTNAME" =~ ^[_a-z0-9-]+\.([_a-z0-9-]+\.?)+$ ]] ; then
+	HOSTNAME="$HOSTNAME.localdomain"
+fi
+
+#
 #  If there are no existing directories beneath /srv/ create a default.
 #
 if [ ! -e "/srv/$HOSTNAME" ] ; then


### PR DESCRIPTION
This adds `.localdomain` to unqualified hostnames.

Closes #57 