### PR TITLE
email: Removed duplicate cron job

### DIFF
--- a/email/debian/changelog
+++ b/email/debian/changelog
@@ -1,3 +1,9 @@
+symbiosis-email (2017:0907) stable; urgency=medium
+
+  * Remove duplicate cron job encrypting passwords.
+
+ -- Patrick J Cherry <patrick@bytemark.co.uk>  Thu, 07 Sep 2017 12:18:45 +0100
+
 symbiosis-email (2017:0904) stable; urgency=medium
 
   * Added ssl-hook to reload dovecot when any SSL certificates are renewed.

--- a/email/debian/maintscript
+++ b/email/debian/maintscript
@@ -11,3 +11,4 @@ rm_conffile /etc/symbiosis/monit.d/exim4 2016:0101
 rm_conffile /etc/symbiosis/monit.d/dovecot 2016:0101
 rm_conffile /etc/symbiosis/monit.d/clamav-freshclam 2016:0101
 rm_conffile /etc/symbiosis/monit.d/clamav-daemon 2016:0101
+rm_conffile /etc/cron.d/symbiosis-email 2017:0907~

--- a/email/debian/symbiosis-email.cron.d
+++ b/email/debian/symbiosis-email.cron.d
@@ -1,9 +1,0 @@
-#
-#  Check that email passwords are encrypted.
-#
-#  If not encrypted, then encrypt
-#
-
-# hourly check
-@hourly root [ -x /usr/sbin/symbiosis-email-encrypt-passwords ] && /usr/sbin/symbiosis-email-encrypt-passwords
-


### PR DESCRIPTION
The symbiosis-email-encrypt-passwords script is symlinked into /etc/cron.daily, hence the duplicate.