### PR TITLE
Update dns.rb to make default dmarc policy safer

### DIFF
--- a/dns/lib/symbiosis/domain/dns.rb
+++ b/dns/lib/symbiosis/domain/dns.rb
@@ -79,7 +79,7 @@ module Symbiosis
 
       return nil unless raw_dmarc
 
-      return 'v=DMARC1; p=quarantine; sp=none' if true == raw_dmarc
+      return 'v=DMARC1; p=none; sp=none; pct=0' if true == raw_dmarc
 
       #
       # Make sure we're not matching against things other than strings.


### PR DESCRIPTION
The current dmarc policy is dangerous, in that it says to quarantine 100% of unaligned email from the main domain (but oddly not subdomains). This policy is much safer for an initial dmarc policy, as recommended for example, by Google at https://support.google.com/a/answer/2466563?hl=en&ref_topic=2759254